### PR TITLE
Add GitHub icon to the page

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,15 +25,27 @@
             init();
         });
     </script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
 </head>
 <body>
-    <h1>GitHub Release Notes Watcher</h1>
+    <div class="header">
+        <a href="https://github.com/joelmnz/github-release-notes-watcher" class="github-icon" target="_blank" title="View on GitHub">
+            <i class="fab fa-github"></i>
+        </a>
+        <h1>GitHub Release Notes Watcher</h1>
+    </div>
     <div id="loading-message">Loading...</div>
     <div id="content" style="display: none;">
         <p>Last updated: <span id="last-updated"></span></p>
-        <button onclick="handleUpdate()" class="update-button">Check for Updates</button>
-        <button onclick="showSettings()" class="settings-button">Settings</button>
-        <button onclick="clearCache()" class="clear-cache-button">Clear Cache</button>
+        <button onclick="handleUpdate()" class="update-button">
+            <i class="fas fa-sync-alt"></i> Check for Updates
+        </button>
+        <button onclick="showSettings()" class="settings-button">
+            <i class="fas fa-cog"></i> Settings
+        </button>
+        <button onclick="clearCache()" class="clear-cache-button">
+            <i class="fas fa-trash-alt"></i> Clear Cache
+        </button>
         <h2>Table of Contents</h2>
         <ul id="toc" class="toc"></ul>
         <div id="releases"></div>

--- a/styles.css
+++ b/styles.css
@@ -177,3 +177,14 @@ a:hover {
     text-decoration: underline;
     transform: scale(1.05); 
 }
+
+.github-icon {
+    font-size: 2em;
+    color: #ffffff;
+    padding: 10px;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+}


### PR DESCRIPTION
Fixes #5

Add a GitHub icon to the page that links to the repository.

* Add a Font Awesome stylesheet link to `index.html`.
* Add a `div` with class `header` containing the GitHub icon and the `h1` tag in `index.html`.
* Add CSS styles for the GitHub icon and the `header` div in `styles.css`.
* Update button elements in `index.html` to include Font Awesome icons.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/joelmnz/github-release-notes-watcher/pull/6?shareId=b27279d1-d5c8-4b37-bb26-7acbdde12b19).