### PR TITLE
Add PWA functionality to allow offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The GitHub Release Notes Watcher is a web application that allows users to monit
 - Provides a fallback mechanism if the `marked` library fails to load.
 - Includes a responsive design with a dark theme.
 - Provides error handling and user feedback for failed repository updates.
+- Functions as a Progressive Web App (PWA) and works offline.
+- Includes a `manifest.json` file to define the PWA settings.
+- Registers a service worker to handle caching and offline functionality.
 
 ## Instructions
 
@@ -28,7 +31,7 @@ The GitHub Release Notes Watcher is a web application that allows users to monit
 5. Use the "Check for Updates" button to manually check for updates.
 6. Use the "Clear Cache" button to clear the cached release notes.
 7. The "Last updated" time will show the last time the release notes were fetched.
-
+8. To use the app offline, add it to your home screen on mobile devices or install it as a PWA on desktop browsers.
 
 ## Acknowledgments
 

--- a/index.html
+++ b/index.html
@@ -26,6 +26,18 @@
         });
     </script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+    <link rel="manifest" href="manifest.json">
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('/service-worker.js').then(registration => {
+                    console.log('ServiceWorker registration successful with scope: ', registration.scope);
+                }, err => {
+                    console.log('ServiceWorker registration failed: ', err);
+                });
+            });
+        }
+    </script>
 </head>
 <body>
     <div class="header">

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "GitHub Release Notes Watcher",
+  "short_name": "Release Notes",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#121212",
+  "theme_color": "#bb86fc",
+  "icons": [
+    {
+      "src": "icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,48 @@
+const CACHE_NAME = 'github-release-notes-watcher-cache-v1';
+const urlsToCache = [
+  '/',
+  '/index.html',
+  '/styles.css',
+  '/manifest.json',
+  '/icons/icon-192x192.png',
+  '/icons/icon-512x512.png',
+  'https://cdn.jsdelivr.net/npm/marked/marked.min.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.3/purify.min.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then(cache => {
+        return cache.addAll(urlsToCache);
+      })
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request)
+      .then(response => {
+        if (response) {
+          return response;
+        }
+        return fetch(event.request);
+      })
+  );
+});
+
+self.addEventListener('activate', event => {
+  const cacheWhitelist = [CACHE_NAME];
+  event.waitUntil(
+    caches.keys().then(cacheNames => {
+      return Promise.all(
+        cacheNames.map(cacheName => {
+          if (!cacheWhitelist.includes(cacheName)) {
+            return caches.delete(cacheName);
+          }
+        })
+      );
+    })
+  );
+});


### PR DESCRIPTION
Related to #11

Add PWA support to enable offline mode.

* **index.html**: Add a link to `manifest.json` and a script to register the service worker.
* **manifest.json**: Add a new file with PWA settings including `name`, `short_name`, `start_url`, `display`, `background_color`, `theme_color`, and `icons`.
* **service-worker.js**: Add a new file to handle caching and offline functionality.
* **README.md**: Update to include PWA-related features and instructions.

